### PR TITLE
fix analyzer warnings

### DIFF
--- a/Classes/DPPPropertyAttribute.m
+++ b/Classes/DPPPropertyAttribute.m
@@ -26,7 +26,7 @@
 		return self;
     
     const char *p = attrs;
-    char retentionMethod;
+    char retentionMethod = 0;
     BOOL atomic = YES;
     BOOL weak = NO;
 	do

--- a/Classes/NSObject+DProperty.m
+++ b/Classes/NSObject+DProperty.m
@@ -208,12 +208,10 @@ static void DPP_initialize()
 {
     NSMutableDictionary *dict = objc_getAssociatedObject(self, &DPPPropertyDictionaryKey);
     if(dict == nil){
-        @synchronized(dict){
-            dict = objc_getAssociatedObject(self, &DPPPropertyDictionaryKey);
-            if(dict == nil){
-                dict = [NSMutableDictionary dictionary];
-                self.DPP_keysDictionary = dict;
-            }
+        dict = objc_getAssociatedObject(self, &DPPPropertyDictionaryKey);
+        if(dict == nil){
+            dict = [NSMutableDictionary dictionary];
+            self.DPP_keysDictionary = dict;
         }
     }
     return dict;


### PR DESCRIPTION
DPPPropertyAttribute.m:60:35: warning: The left operand of '==' is a garbage value
NSObject+DProperty.m:211:9: warning: Nil value used as mutex for @synchronized() (no synchronization will occur)
